### PR TITLE
Response with no items

### DIFF
--- a/elasticsearch_dsl/search.py
+++ b/elasticsearch_dsl/search.py
@@ -148,9 +148,9 @@ class Search(object):
             if n.start and n.start < 0 or n.stop and n.stop < 0:
                 raise ValueError("Search does not support negative slicing.")
             # Elasticsearch won't get all results so we default to size: 10 if
-            # stop not given.
+            # stop not given. [0:0] for an empty Response.
             s._extra['from'] = n.start or 0
-            s._extra['size'] = n.stop - (n.start or 0) if n.stop else 10
+            s._extra['size'] = n.stop - (n.start or 0) if n.stop is not None else 10
             return s
         else:  # This is an index lookup, equivalent to slicing by [n:n+1].
             # If negative index, abort.


### PR DESCRIPTION
I know we can't cover all the slicing API features, but it could be very useful having a syntax to ask for 0 items.
I use it when I need aggregations, or I need to know how many items respond to my query.